### PR TITLE
ミスタイポ修正

### DIFF
--- a/articles/7a3b5e04ef04222f6a99.md
+++ b/articles/7a3b5e04ef04222f6a99.md
@@ -9,7 +9,7 @@ published: true
 # 特定のポートをListen状態にしたい（簡易的なWebサーバーを立てたい）
 - `nc -l ${port_num}`: ${port_num}をListen状態にする
   ```
-  $ ss -antu # 12345ポートをncコマンドでListen状態にすたときの確認
+  $ ss -antu # 12345ポートをncコマンドでListen状態にしたときの確認
   tcp      LISTEN    0         1                         0.0.0.0:12345              0.0.0.0:*
   ```
 - `nc -kl ${port_num}`: `-k`オプションで複数クライアントからの待ち受けを可能にする


### PR DESCRIPTION
`す` -> `し`